### PR TITLE
Accept bids

### DIFF
--- a/controllers/bidController.js
+++ b/controllers/bidController.js
@@ -30,11 +30,18 @@ router.get('/new/:id', async (req,res)=>{
 //create bid
 router.post('/events/:id/', async (req,res)=>{
     try{
+        // find event first to get "bossId" for the new bid 
+        const foundEvent = await Events.findById(req.params.id);
+
+
         const newBid = req.body;
         newBid.bidderId = req.session.userId;
+        newBid.bossId = foundEvent.hostId;
+
         const createdBid = await Bids.create(newBid);
 
-        const foundEvent = await Events.findById(req.params.id);
+        console.log("created Bid: ", createdBid);
+
         const currentUser = await Users.findById(req.session.userId);
         const currentServiceId = currentUser.services[0]._id;
         const currentService = await Services.findById(currentServiceId);

--- a/controllers/bidController.js
+++ b/controllers/bidController.js
@@ -149,10 +149,8 @@ router.patch('/:id', async (req, res)=>{
 
     if (req.body.accepted === "yes") {
         update.accepted = true;
-        update.bossId = req.session.userId;
     } else {
         update.accepted = false;
-        update.bossId = null;
     }
             
      try {
@@ -170,7 +168,7 @@ router.patch('/:id', async (req, res)=>{
         // 1. service.bids in DB
         // 2. event.services in DB 
         // 3. user.events.services for the BOSS user -- update WITh updated event from 1, save 
-        // 4. user.services[0].bids on BIDDER user -- update WITH updated service.bids from 2, save 
+        // 4. user.services.bids on BIDDER user -- update WITH updated service.bids from 2, save 
 
 
         // first, capture these NOW, before shit gets WEIRD: 
@@ -223,7 +221,7 @@ router.patch('/:id', async (req, res)=>{
         console.log("updated boss User: ", updatedBossUser);
 
 
-        // 4. user.services[0].bids on BIDDER user -- update WITH updated service.bids from 2, save 
+        // 4. user.services.bids on BIDDER user -- update WITH updated service.bids from 2, save 
         const bidderServiceIndex = bidder.services.findIndex((service)=>{
             if (service._id.toString()===foundServiceIdString) {
                 return true;
@@ -245,53 +243,6 @@ router.patch('/:id', async (req, res)=>{
         console.log(err);
     }
 })
-
-        // different iterations of stuff while figuring out above code: 
-
-        // await foundService.bids.id(req.params.id).remove();  
-        // await foundService.bids.push(bid);
-        // await foundService.save();
-
-        // // find the bid in the users' services' bids array and remove it then push it
-        // const updatedBidInUserServices = await user.services.id(foundService._id).bids.id(req.params.id).remove();
-        // console.log(updatedBidInUserServices);
-        // await user.services.id(foundService._id).bids.push(bid);
-        // await user.save();
-
-        // // find the bid in the events services array remove and push updated
-        // const updatedBidInEventServices = await event.services.id(req.params.id).remove();
-        // console.log('events =============');
-        // console.log(updatedBidInEventServices);
-        // event.services.push(bid);
-        // await event.save();
-
-
-
-        // const foundService = await Services.findOne({'bids._id': req.params.id});
-        // const bidder = await Users.findById(bid.bidderId);
-        // const event = await Events.findOne({'services._id': req.params.id});
-
-        // console.log("found service: ", foundService);
-        // console.log("found user: ", bidder);
-        // console.log("found event: ", event);
-
-        // // update in the foundService FIRST 
-        // await foundService.bids.id(req.params.id).remove();  
-        // await foundService.bids.push(bid);
-        // await foundService.save();
-
-        // // find the bid in the users' services' bids array, remove, push updated bid, SAVE
-        // // The Problem is in the next line of CODE!!! 
-
-        // const updatedBidInUserServices = await bidder.services.id(foundService._id).bids.id(req.params.id).remove();
-        // await bidder.services.id(foundService._id).bids.push(bid);
-        // await bidder.save();
-
-        // // find the bid in the events services array remove and push updated
-        // const updatedBidInEventServices = await event.services.id(req.params.id).remove();
-        // event.services.push(bid);
-        // await event.save();
-
 
 
 router.delete('/:id', async (req,res)=>{

--- a/controllers/eventsController.js
+++ b/controllers/eventsController.js
@@ -134,10 +134,14 @@ router.post('/', async (req, res) => {
     console.log(req.session);
     if(req.session.logged == true) {
         try {
-            const newEvent = await Events.create(req.body);
             const host = await Users.findById(req.session.userId)
+            const eventData = req.body;
+            eventData.hostId = host._id.toString();
+            const newEvent = await Events.create(eventData);
+
             host.events.push(newEvent);
-            host.save()
+            const updatedHost = await host.save();
+
             res.redirect('/events');
         } catch (err) {
             res.send(err)

--- a/models/Bid.js
+++ b/models/Bid.js
@@ -3,7 +3,10 @@ const mongoose = require('mongoose');
 const bidSchema = mongoose.Schema({
     title: {type: String, required: true},
     bidAmount: {type: Number, required: true},
-    note: String
+    note: String,
+    bidderId: String,
+    bossId: String,
+    accepted: {type: Boolean, default: false}
 });
 
 module.exports = mongoose.model('Bid', bidSchema);

--- a/models/Event.js
+++ b/models/Event.js
@@ -9,7 +9,6 @@ const eventSchema = mongoose.Schema({
     date: {type: Date},
     description: {type: String, require: true},
     services: [Bids.schema], // TBD if we need this imported or if this will just be a drop down
-    hostId: String,
     servicesNeeded: [ {type: String} ],
     budget: Number,
     image: String

--- a/models/Event.js
+++ b/models/Event.js
@@ -10,9 +10,13 @@ const eventSchema = mongoose.Schema({
     description: {type: String, require: true},
     services: [Bids.schema], // TBD if we need this imported or if this will just be a drop down
     servicesNeeded: [ {type: String} ],
+    hostId: String, // need the hostId if you want to set bossId on bid creation
     budget: Number,
     image: String
 })
+
+// NOTE: want to set bossId on bid creation so that we can set proper access / restrictions on who 
+// can accept or reject a bid 
 
 const Event = mongoose.model('Event', eventSchema)
 module.exports = Event;

--- a/models/Event.js
+++ b/models/Event.js
@@ -9,7 +9,7 @@ const eventSchema = mongoose.Schema({
     date: {type: Date},
     description: {type: String, require: true},
     services: [Bids.schema], // TBD if we need this imported or if this will just be a drop down
-    // hostId: String,
+    hostId: String,
     servicesNeeded: [ {type: String} ],
     budget: Number,
     image: String

--- a/models/User.js
+++ b/models/User.js
@@ -9,7 +9,7 @@ const userSchema = mongoose.Schema({
     lastname: String,
     email: String,
     events: [Events.schema],
-    services: [Services.schema],
+    services: [Services.schema], // only one for now, per user, at a time 
     zipCode: String,
     image: String
 });

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -185,10 +185,3 @@ footer a {
 .event-show {
     margin-left: 30%;
 }
-
-
-/* ========== ABOUT PAGE ========== */
-
-
-
-

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -185,3 +185,10 @@ footer a {
 .event-show {
     margin-left: 30%;
 }
+
+
+/* ========== ABOUT PAGE ========== */
+
+
+
+

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
+require('dotenv').config(); // IMPORTANT: This must come before you require your database! 
+
 require('./db/db');
-require('dotenv').config();
 const express               = require('express');
 const app                   = express();
 const morgan                = require('morgan');
@@ -30,7 +31,7 @@ const bidController         = require('./controllers/bidController');
 
 // session
 app.use(session({
-    secret: "THIS IS A RANDOM STRING SECRET",
+    secret: process.env.SESSION_SECRET,
     resave: true,
     saveUninitialized: true,
     cookie: {

--- a/views/bids/show.ejs
+++ b/views/bids/show.ejs
@@ -27,6 +27,24 @@
                 <hr class="my-5">
                 <h1>$<%=bid.bidAmount%><h1>
                 <hr class="my-5">
+                <h3>Status: <% if (bid.accepted) { -%>
+                    Accepted
+                <% } else { -%>
+                    Rejected
+                <% } -%></h3>
+                <h4>Accept Bid: </h4>
+                <form action="/bids/<%=bid._id%>?_method=PATCH" method="POST">
+                    <select name="accepted">
+                        <% if (bid.accepted) { -%>
+                            <option selected value="yes">Yes</option>
+                            <option value="no">No</option>
+                        <% } else { -%>
+                            <option value="yes">Yes</option>
+                            <option selected value="no">No</option>      
+                        <% } -%>
+                    </select>
+                    <button class="btn">Submit Change</button>
+                </form>
             </div>
             <div class="col-3">
                 <% if (currentSession.logged === true && (user._id.toString() === currentUserId.toString())) { %>

--- a/views/bids/show.ejs
+++ b/views/bids/show.ejs
@@ -22,29 +22,41 @@
             </div> 
             <div class="col-5">
                 <h2><%=bid.title%></h2>
-                
                 <h3 class="display-8">Bid Amount $$</h1>
                 <hr class="my-5">
                 <h1>$<%=bid.bidAmount%><h1>
                 <hr class="my-5">
-                <h3>Status: <% if (bid.accepted) { -%>
-                    Accepted
-                <% } else { -%>
-                    Rejected
-                <% } -%></h3>
-                <h4>Accept Bid: </h4>
-                <form action="/bids/<%=bid._id%>?_method=PATCH" method="POST">
-                    <select name="accepted">
-                        <% if (bid.accepted) { -%>
-                            <option selected value="yes">Yes</option>
-                            <option value="no">No</option>
+
+                <!-- display for user if user is bidder:  -->
+                <% if (currentUserId.toString()===bid.bidderId) { -%>
+                    <h3>Status: <% if (bid.accepted) { -%>
+                            Accepted
                         <% } else { -%>
-                            <option value="yes">Yes</option>
-                            <option selected value="no">No</option>      
-                        <% } -%>
-                    </select>
-                    <button class="btn">Submit Change</button>
-                </form>
+                            Rejected
+                        <% } -%></h3>
+                <% }  -%>
+
+                <!-- display for user if user is boss: -->
+                <% if (currentUserId.toString()===bid.bossId) { -%>
+                    <h3>Status: <% if (bid.accepted) { -%>
+                        Accepted
+                    <% } else { -%>
+                        Rejected
+                    <% } -%></h3>
+                    <h4>Accept Bid: </h4>
+                    <form action="/bids/<%=bid._id%>?_method=PATCH" method="POST">
+                        <select name="accepted">
+                            <% if (bid.accepted) { -%>
+                                <option selected value="yes">Yes</option>
+                                <option value="no">No</option>
+                            <% } else { -%>
+                                <option value="yes">Yes</option>
+                                <option selected value="no">No</option>      
+                            <% } -%>
+                        </select>
+                        <button class="btn">Submit Change</button>
+                    </form>
+                <% } -%>
             </div>
             <div class="col-3">
                 <% if (currentSession.logged === true && (user._id.toString() === currentUserId.toString())) { %>


### PR DESCRIPTION
Several changes but I achieved the target functionality. After our discussions via slack I thought harder and figured out a way to have bid acceptance edited in the correct locations, and did so without scaling back the current inter-model connectivity, AND ALSO avoided having to hardcode any index searches. 

I created a new PATCH route to alter bid acceptance and, naturally, added an "accepted" Boolean to the Bid model. 

(NOTE: I did *not* change the basic bid editing route (the one via PUT route) to incorporate these changes, but you can feel free to reuse any of the code I wrote for the PATCH route wherever you like.) 

I added logic to the bids view page so that the bid status (accepted/not accepted) will appear, but only if the current user (as per req.session) is either the bidder or the "boss" (the one who created the event and to whom the bid was submitted). The boss can see the status AND choose either "Yes" or "No" to change that bid's status to accepted or rejected. The bidder can then see this updated status when s/he is logged in. 

Adding this functionality required changes in a number of places, including to the models. E.g., bids now have a bidderId and bossId associated with them, and events have a hostId. Each of these are set upon creation of the bid or event, and should be retained unaltered until/unless the bid or event is deleted. Adding these in could be useful for other functionality you might want to incorporate down the road. 

I tried to add in comments to clarify, and I believe I made only those changes that were necessary for the functionality outlined above. Nonetheless if anything is unclear / suspect feel free to reach out and I will explain as best I can. 

I believe there are some patches of aborted code grayed out here or there, and some functionally unnecessary console.logs that I used while testing my changes. I opted to leave most of those in, so as to aid your integration and bugtesting of my code. 